### PR TITLE
Added Overlord UI Build values from S3

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,19 +8,51 @@ const fs = require("fs");
 const moment = require("moment");
 
 const secretsmanager = require("aws-sdk/clients/secretsmanager");
+const s3 = require("aws-sdk/clients/s3");
 
 AWS.config.logger = console;
+
+const fetchOverlordConfigValues = async (currentEnvironment) => {
+  try {
+    const s3Client = new s3({
+      region: process.env.AWS_DEFAULT_REGION || "us-west-2",
+    });
+
+    const eventNameAbbr = process.env.AWS_SECRETSMANAGER_SECRET_ID.split(
+      "-"
+    )[1];
+
+    const { Body } = await s3Client
+      .getObject({
+        Bucket: `onlineeventpro-content-${currentEnvironment}`,
+        Key: `onlineeventpro-${eventNameAbbr}-api/ui-build-config.json`,
+      })
+      .promise();
+
+    const overlordUIBuildConfig = JSON.parse(Body);
+
+    return overlordUIBuildConfig;
+  } catch (err) {
+    debug("secrets-to-env:error")(
+      "Failed in the fetchOverlordConfigValues() function:",
+      err.message
+    );
+    return null;
+  }
+};
 
 const init = async () => {
   try {
     const secretsManagerClient = new secretsmanager({
       region: process.env.AWS_DEFAULT_REGION || "us-west-2",
     });
+
     const response = await secretsManagerClient
       .getSecretValue({
         SecretId: process.env.AWS_SECRETSMANAGER_SECRET_ID,
       })
       .promise();
+
     const secrets = JSON.parse(response.SecretString);
     let EnvString = `\n########## Retrieved ${moment().format(
       "llll"
@@ -35,9 +67,31 @@ const init = async () => {
       }
     }
     EnvString += "\n";
+
+    const overlordConfigValues = await fetchOverlordConfigValues(
+      secrets.REACT_APP_ENV
+    );
+
+    let successMessage = "✅ The .env file has been written!";
+
+    if (overlordConfigValues) {
+      EnvString += `\n########## Overlord config build values ##########\n`;
+
+      for (let [key, value] of Object.entries(overlordConfigValues)) {
+        const formattedKey = key
+          .split(/(?=[A-Z])/) // camelCase to UPPER_SNAKE_CASE
+          .map((fragment) => fragment.toUpperCase())
+          .join("_");
+        process.env[formattedKey] = value;
+
+        EnvString += `REACT_APP_${formattedKey}="${value}"\n`;
+      }
+      successMessage = `✅ Overlord UI build config values has been added! \n${successMessage}`;
+    }
+
     fs.writeFile(".env", EnvString, { flag: "a" }, (err) => {
       if (err) throw err;
-      debug("secrets-to-env:info")("✅ The .env file has been written!");
+      debug("secrets-to-env:info")(successMessage);
     });
   } catch (err) {
     debug("secrets-to-env:error")("Failed in the init() function:", err.stack);


### PR DESCRIPTION
_This PR, as well as all the PRs from "envs to config" epic to product-ui, product-api and product-fn are to enable product to consume values set by overlord. This PRs are to be tested and merged after overlord UI, API and FN is done and the values to be consumed are set._

Added functionality to pull UI Build config values from S3 and add then to .env file 

Jira ticket: https://freemandigital.atlassian.net/browse/OEP-10778

[Jira envs to config epic](https://freemandigital.atlassian.net/browse/OEP-6680)